### PR TITLE
fix broken url

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+from logging import error
 import telegram.ext as telegram_bot
 import src.functions as funcs
 import credentials
@@ -11,9 +12,7 @@ disp.add_handler(telegram_bot.CommandHandler("time", funcs.time))
 disp.add_handler(
     telegram_bot.CommandHandler("abouthacktoberfest", funcs.abouthacktoberfest)
 )
-disp.add_handler(telegram_bot.CommandHandler("hacktoberfest", funcs.hacktoberfest))
-disp.add_handler(telegram_bot.CommandHandler("repo", funcs.repo))
-
+updater.dispatcher.add_error_handler(error)
 updater.start_polling()
 updater.idle()
 

--- a/src/functions.py
+++ b/src/functions.py
@@ -1,5 +1,6 @@
 import datetime
-import webbrowser
+from telegram import InlineKeyboardMarkup, bot
+from telegram.inline.inlinekeyboardbutton import InlineKeyboardButton
 
 
 def start(update, context):
@@ -36,19 +37,24 @@ def abouthacktoberfest(update, context):
         r"""
         Hacktoberfest encourages participation in the open source community, which grows bigger every year. Complete the 2021 challenge and earn a limited edition T-shirt.
 
-And also this bot is included in Hacktoberfest repo. For more information check
-
-        /hacktoberfest -> Go to Hacktoberfest website
-        /repo -> Go to this Bot repository
-        """
+And also this bot is included in Hacktoberfest repo. For more information check the url below.
+        """,
+        reply_markup=urlKeyboard(),
     )
 
 
-def hacktoberfest(update, context):
-    webbrowser.open("https://hacktoberfest.digitalocean.com/")
-    update.message.reply_text("Open Hacktoberfest on web browser.")
-
-
-def repo(update, context):
-    webbrowser.open("https://github.com/Jonak-Adipta-Kalita/JAK-Telegram-Bot")
-    update.message.reply_text("Open bot repository.")
+def urlKeyboard():
+    keyboard = [
+        [
+            InlineKeyboardButton(
+                "Hacktoberfest", url="https://hacktoberfest.digitalocean.com/"
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                "Bot Repository",
+                url="https://github.com/Jonak-Adipta-Kalita/JAK-Telegram-Bot",
+            )
+        ],
+    ]
+    return InlineKeyboardMarkup(keyboard)


### PR DESCRIPTION
I change the `webbrowser` to `reply_markup` for directing the url.

- [x] Checked using heroku
- [x] Formatting the code

![example](https://i.ibb.co/8894C10/image.png)

**PS** Sorry if it can’t automatically merged, I tried to fix it but nothing happen.